### PR TITLE
Add new commands squashed

### DIFF
--- a/src/Unit/AbstractUnit.php
+++ b/src/Unit/AbstractUnit.php
@@ -2,7 +2,9 @@
 
 namespace SystemCtl\Unit;
 
+use Symfony\Component\Process\Process;
 use Symfony\Component\Process\ProcessBuilder;
+use SystemCtl\Exception\CommandFailedException;
 
 abstract class AbstractUnit implements UnitInterface
 {
@@ -64,33 +66,96 @@ abstract class AbstractUnit implements UnitInterface
      */
     abstract protected function execute(string $command): bool;
 
+    /**
+     * @param string $command
+     *
+     * @return Process
+     */
+    protected function runCommandAgainstService(string $command): Process
+    {
+        $process = $this->processBuilder
+            ->setArguments([$command, $this->getName()])
+            ->getProcess();
+
+
+        $process->run();
+
+        return $process;
+    }
+
+    /**
+     * @return bool
+     */
     public function start(): bool
     {
         return $this->execute(__FUNCTION__);
     }
 
+    /**
+     * @return bool
+     */
     public function stop(): bool
     {
         return $this->execute(__FUNCTION__);
     }
 
+    /**
+     * @return bool
+     */
     public function disable(): bool
     {
         return $this->execute(__FUNCTION__);
     }
 
+    /**
+     * @return bool
+     */
     public function reload(): bool
     {
         return $this->execute(__FUNCTION__);
     }
 
+    /**
+     * @return bool
+     */
     public function restart(): bool
     {
         return $this->execute(__FUNCTION__);
     }
 
+    /**
+     * @return bool
+     */
     public function enable(): bool
     {
         return $this->execute(__FUNCTION__);
+    }
+
+    /**
+     * @return bool
+     */
+    public function isEnabled(): bool
+    {
+        $process = $this->runCommandAgainstService('is-enabled');
+
+        return $process->isSuccessful() && trim($process->getOutput()) === 'enabled';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isActive(): bool
+    {
+        $process = $this->runCommandAgainstService('is-active');
+
+        return $process->isSuccessful() && trim($process->getOutput()) === 'active';
+    }
+
+    /**
+     * @return bool
+     */
+    public function isRunning(): bool
+    {
+        return $this->isActive();
     }
 }

--- a/src/Unit/Service.php
+++ b/src/Unit/Service.php
@@ -1,21 +1,24 @@
 <?php
 
-
 namespace SystemCtl\Unit;
 
 use SystemCtl\Exception\CommandFailedException;
 
 class Service extends AbstractUnit
 {
+    /**
+     * @var string
+     */
     public const UNIT = 'service';
 
+    /**
+     * @inheritdoc
+     *
+     * @throws \SystemCtl\Exception\CommandFailedException
+     */
     protected function execute(string $command): bool
     {
-        $process = $this->processBuilder
-            ->setArguments([$command, $this->getName()])
-            ->getProcess();
-
-        $process->run();
+        $process = $this->runCommandAgainstService($command);
 
         if (!$process->isSuccessful()) {
             throw CommandFailedException::fromService($this->getName(), $command);

--- a/src/Unit/Timer.php
+++ b/src/Unit/Timer.php
@@ -6,15 +6,19 @@ use SystemCtl\Exception\CommandFailedException;
 
 class Timer extends AbstractUnit
 {
+    /**
+     * @var string
+     */
     public const UNIT = 'timer';
 
+    /**
+     * @inheritdoc
+     *
+     * @throws \SystemCtl\Exception\CommandFailedException
+     */
     protected function execute(string $command): bool
     {
-        $process = $this->processBuilder
-            ->setArguments([$command, $this->getName()])
-            ->getProcess();
-
-        $process->run();
+        $process = $this->runCommandAgainstService($command);
 
         if (!$process->isSuccessful()) {
             throw CommandFailedException::fromTimer($this->getName(), $command);

--- a/tests/Unit/Unit/AbstractUnitTest.php
+++ b/tests/Unit/Unit/AbstractUnitTest.php
@@ -248,8 +248,7 @@ class AbstractUnitTest extends TestCase
     public function itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActive(
         $commandSuccessful,
         $commandOutput
-    )
-    {
+    ) {
         $processBuilderStub = $this->buildProcessBuilderMock($commandSuccessful, $commandOutput);
         $processBuilderStub->setArguments(['is-active', static::SERVICE_NAME,])->willReturn($processBuilderStub);
 

--- a/tests/Unit/Unit/AbstractUnitTest.php
+++ b/tests/Unit/Unit/AbstractUnitTest.php
@@ -145,4 +145,152 @@ class AbstractUnitTest extends TestCase
             ],
         ];
     }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnTrueIfServiceEnabledCommandRanSuccessfully()
+    {
+        $processBuilderStub = $this->buildProcessBuilderMock(true, 'enabled');
+        $processBuilderStub->setArguments(['is-enabled', static::SERVICE_NAME,])->willReturn($processBuilderStub);
+
+        $unit = new UnitStub(static::SERVICE_NAME, $processBuilderStub->reveal());
+
+        $this->assertTrue($unit->isEnabled());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnFalseIfServiceEnabledCommandFailed()
+    {
+        $processBuilderStub = $this->buildProcessBuilderMock(false, 'enabled');
+        $processBuilderStub->setArguments(['is-enabled', static::SERVICE_NAME,])->willReturn($processBuilderStub);
+
+        $unit = new UnitStub(static::SERVICE_NAME, $processBuilderStub->reveal());
+
+        $this->assertFalse($unit->isEnabled());
+    }
+
+    /**
+     * @param bool $commandSuccessful
+     * @param string $commandOutput
+     *
+     * @test
+     * @dataProvider itShouldReturnFalseIfServiceEnabledCommandOutputDoesNotEqualEnabledDataProvider
+     */
+    public function itShouldReturnFalseIfServiceEnabledCommandOutputDoesNotEqualEnabled($commandSuccessful, $commandOutput)
+    {
+        $processBuilderStub = $this->buildProcessBuilderMock($commandSuccessful, $commandOutput);
+        $processBuilderStub->setArguments(['is-enabled', static::SERVICE_NAME,])->willReturn($processBuilderStub);
+
+        $unit = new UnitStub(static::SERVICE_NAME, $processBuilderStub->reveal());
+
+        $this->assertFalse($unit->isEnabled());
+    }
+
+    /**
+     * @return array
+     */
+    public function itShouldReturnFalseIfServiceEnabledCommandOutputDoesNotEqualEnabledDataProvider(): array
+    {
+        return [
+            [
+                'commandSuccessful' => true,
+                'commandOutput' => 'static',
+            ],
+            [
+                'commandSuccessful' => false,
+                'commandOutput' => 'static',
+            ],
+            [
+                'commandSuccessful' => true,
+                'commandOutput' => 'enable',
+            ],
+        ];
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnTrueIfServiceActiveCommandRanSuccessfully()
+    {
+        $processBuilderStub = $this->buildProcessBuilderMock(true, 'active');
+        $processBuilderStub->setArguments(['is-active', static::SERVICE_NAME,])->willReturn($processBuilderStub);
+
+        $unit = new UnitStub(static::SERVICE_NAME, $processBuilderStub->reveal());
+
+        $this->assertTrue($unit->isRunning());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnFalseIfServiceActiveCommandFailed()
+    {
+        $processBuilderStub = $this->buildProcessBuilderMock(false, 'active');
+        $processBuilderStub->setArguments(['is-active', static::SERVICE_NAME,])->willReturn($processBuilderStub);
+
+        $unit = new UnitStub(static::SERVICE_NAME, $processBuilderStub->reveal());
+
+        $this->assertFalse($unit->isRunning());
+    }
+
+    /**
+     * @param bool $commandSuccessful
+     * @param string $commandOutput
+     *
+     * @test
+     * @dataProvider itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActiveDataProvider
+     */
+    public function itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActive($commandSuccessful, $commandOutput)
+    {
+        $processBuilderStub = $this->buildProcessBuilderMock($commandSuccessful, $commandOutput);
+        $processBuilderStub->setArguments(['is-active', static::SERVICE_NAME,])->willReturn($processBuilderStub);
+
+        $unit = new UnitStub(static::SERVICE_NAME, $processBuilderStub->reveal());
+
+        $this->assertFalse($unit->isRunning());
+    }
+
+    /**
+     * @return array
+     */
+    public function itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActiveDataProvider(): array
+    {
+        return [
+            [
+                'commandSuccessful' => true,
+                'commandOutput' => 'static',
+            ],
+            [
+                'commandSuccessful' => false,
+                'commandOutput' => 'static',
+            ],
+            [
+                'commandSuccessful' => true,
+                'commandOutput' => 'enable',
+            ],
+        ];
+    }
+
+    /**
+     * @param bool   $processRanSuccessful
+     * @param string $processOutput
+     *
+     * @return \Prophecy\Prophecy\ObjectProphecy
+     */
+    private function buildProcessBuilderMock($processRanSuccessful = true, $processOutput = ''): ObjectProphecy
+    {
+        $processBuilderStub = $this->prophesize(ProcessBuilder::class);
+
+        $processStub = $this->prophesize(Process::class);
+        $processStub->run()->willReturn(!$processRanSuccessful);
+        $processStub->isSuccessful()->willReturn($processRanSuccessful);
+        $processStub->getOutput()->willReturn($processOutput);
+
+        $processBuilderStub->getProcess()->willReturn($processStub);
+
+        return $processBuilderStub;
+    }
 }

--- a/tests/Unit/Unit/AbstractUnitTest.php
+++ b/tests/Unit/Unit/AbstractUnitTest.php
@@ -179,8 +179,10 @@ class AbstractUnitTest extends TestCase
      * @test
      * @dataProvider itShouldReturnFalseIfServiceEnabledCommandOutputDoesNotEqualEnabledDataProvider
      */
-    public function itShouldReturnFalseIfServiceEnabledCommandOutputDoesNotEqualEnabled($commandSuccessful, $commandOutput)
-    {
+    public function itShouldReturnFalseIfServiceEnabledCommandOutputDoesNotEqualEnabled(
+        $commandSuccessful,
+        $commandOutput
+    ) {
         $processBuilderStub = $this->buildProcessBuilderMock($commandSuccessful, $commandOutput);
         $processBuilderStub->setArguments(['is-enabled', static::SERVICE_NAME,])->willReturn($processBuilderStub);
 
@@ -243,7 +245,10 @@ class AbstractUnitTest extends TestCase
      * @test
      * @dataProvider itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActiveDataProvider
      */
-    public function itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActive($commandSuccessful, $commandOutput)
+    public function itShouldReturnFalseIfServiceActiveCommandOutputDoesNotEqualActive(
+        $commandSuccessful,
+        $commandOutput
+    )
     {
         $processBuilderStub = $this->buildProcessBuilderMock($commandSuccessful, $commandOutput);
         $processBuilderStub->setArguments(['is-active', static::SERVICE_NAME,])->willReturn($processBuilderStub);


### PR DESCRIPTION
As I said in #4, this is the PR which introduces new commands for the services.

`isEnabled`, `isActive` and `isRunning`. The latter on is basically an alias for `isActive`.

I have included the commit from #4  in this ticket to make it work properly. I hope this is okay.
Therefore this PR relies either on merging #4 first or just merge it as a whole :)

Open for questions.