### PR TITLE
Add tests to prove broken behavior.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,4 +18,4 @@ before_script:
 script:
   - composer cs
   - composer test -- --coverage-clover=build/logs/clover.xml --coverage-text
-  - ./vendor/bin/test-reporter
+  - 'if [ "$TRAVIS_PULL_REQUEST" == "false" ]; then ./vendor/bin/test-reporter; fi'

--- a/src/Command/CommandDispatcherInterface.php
+++ b/src/Command/CommandDispatcherInterface.php
@@ -4,6 +4,11 @@ namespace SystemCtl\Command;
 
 use SystemCtl\Exception\CommandFailedException;
 
+/**
+ * Interface CommandDispatcherInterface
+ *
+ * @package SystemCtl\Command
+ */
 interface CommandDispatcherInterface
 {
     /**

--- a/src/Exception/CommandFailedException.php
+++ b/src/Exception/CommandFailedException.php
@@ -2,6 +2,11 @@
 
 namespace SystemCtl\Exception;
 
+/**
+ * Class CommandFailedException
+ *
+ * @package SystemCtl\Exception
+ */
 class CommandFailedException extends \Exception
 {
 }

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -9,4 +9,6 @@ use Throwable;
  *
  * @package SystemCtl\Exception
  */
-interface ExceptionInterface extends Throwable {}
+interface ExceptionInterface extends Throwable
+{
+}

--- a/src/Exception/ExceptionInterface.php
+++ b/src/Exception/ExceptionInterface.php
@@ -1,0 +1,12 @@
+<?php
+
+namespace SystemCtl\Exception;
+
+use Throwable;
+
+/**
+ * Interface ExceptionInterface
+ *
+ * @package SystemCtl\Exception
+ */
+interface ExceptionInterface extends Throwable {}

--- a/src/Exception/UnitNotFoundException.php
+++ b/src/Exception/UnitNotFoundException.php
@@ -1,0 +1,26 @@
+<?php
+
+namespace SystemCtl\Exception;
+
+use RuntimeException;
+
+/**
+ * Class UnitNotFoundException
+ *
+ * @package SystemCtl\Exception
+ */
+class UnitNotFoundException extends RuntimeException implements ExceptionInterface
+{
+    /**
+     * @param string $type
+     * @param string $name
+     *
+     * @return UnitNotFoundException
+     */
+    public static function create(string $type, string $name): self
+    {
+       return new self(
+           sprintf('Could not find %s "%s"', ucfirst($type), $name)
+       );
+    }
+}

--- a/src/Exception/UnitNotFoundException.php
+++ b/src/Exception/UnitNotFoundException.php
@@ -19,8 +19,8 @@ class UnitNotFoundException extends RuntimeException implements ExceptionInterfa
      */
     public static function create(string $type, string $name): self
     {
-       return new self(
-           sprintf('Could not find %s "%s"', ucfirst($type), $name)
-       );
+        return new self(
+            sprintf('Could not find %s "%s"', ucfirst($type), $name)
+        );
     }
 }

--- a/src/Exception/UnitTypeNotSupportedException.php
+++ b/src/Exception/UnitTypeNotSupportedException.php
@@ -3,6 +3,11 @@
 
 namespace SystemCtl\Exception;
 
+/**
+ * Class UnitTypeNotSupportedException
+ *
+ * @package SystemCtl\Exception
+ */
 class UnitTypeNotSupportedException extends \Exception
 {
 

--- a/src/Unit/AbstractUnit.php
+++ b/src/Unit/AbstractUnit.php
@@ -2,9 +2,14 @@
 
 namespace SystemCtl\Unit;
 
-use Symfony\Component\Process\Process;
 use SystemCtl\Command\CommandDispatcherInterface;
+use SystemCtl\Command\CommandInterface;
 
+/**
+ * Class AbstractUnit
+ *
+ * @package SystemCtl\Unit
+ */
 abstract class AbstractUnit implements UnitInterface
 {
     /** @var string */
@@ -12,6 +17,11 @@ abstract class AbstractUnit implements UnitInterface
 
     /** @var CommandDispatcherInterface */
     protected $commandDispatcher;
+
+    /**
+     * @var string
+     */
+    protected $unitSuffix;
 
     /**
      * Create new service with given name
@@ -58,11 +68,34 @@ abstract class AbstractUnit implements UnitInterface
     }
 
     /**
+     * @return string
+     */
+    abstract protected function getUnitSuffix(): string;
+
+    /**
+     * @param array $commands
+     *
+     * @return CommandInterface
+     */
+    public function execute(...$commands): CommandInterface
+    {
+        $commands[] = implode(
+            '.',
+            [
+                $this->name,
+                $this->getUnitSuffix(),
+            ]
+        );
+
+        return $this->commandDispatcher->dispatch(...$commands);
+    }
+
+    /**
      * @return bool
      */
     public function start(): bool
     {
-        return $this->commandDispatcher->dispatch(__FUNCTION__)->isSuccessful();
+        return $this->execute(__FUNCTION__)->isSuccessful();
     }
 
     /**
@@ -70,7 +103,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function stop(): bool
     {
-        return $this->commandDispatcher->dispatch(__FUNCTION__)->isSuccessful();
+        return $this->execute(__FUNCTION__)->isSuccessful();
     }
 
     /**
@@ -78,7 +111,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function disable(): bool
     {
-        return $this->commandDispatcher->dispatch(__FUNCTION__)->isSuccessful();
+        return $this->execute(__FUNCTION__)->isSuccessful();
     }
 
     /**
@@ -86,7 +119,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function reload(): bool
     {
-        return $this->commandDispatcher->dispatch(__FUNCTION__)->isSuccessful();
+        return $this->execute(__FUNCTION__)->isSuccessful();
     }
 
     /**
@@ -94,7 +127,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function restart(): bool
     {
-        return $this->commandDispatcher->dispatch(__FUNCTION__)->isSuccessful();
+        return $this->execute(__FUNCTION__)->isSuccessful();
     }
 
     /**
@@ -102,7 +135,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function enable(): bool
     {
-        return $this->commandDispatcher->dispatch(__FUNCTION__)->isSuccessful();
+        return $this->execute(__FUNCTION__)->isSuccessful();
     }
 
     /**
@@ -110,7 +143,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function isEnabled(): bool
     {
-        $output = $this->commandDispatcher->dispatch('is-enabled')->getOutput();
+        $output = $this->execute('is-enabled')->getOutput();
 
         return trim($output) === 'enabled';
     }
@@ -120,7 +153,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function isActive(): bool
     {
-        $output = $this->commandDispatcher->dispatch('is-active')->getOutput();
+        $output = $this->execute('is-active')->getOutput();
 
         return trim($output) === 'active';
     }

--- a/src/Unit/Service.php
+++ b/src/Unit/Service.php
@@ -2,10 +2,23 @@
 
 namespace SystemCtl\Unit;
 
+/**
+ * Class Service
+ *
+ * @package SystemCtl\Unit
+ */
 class Service extends AbstractUnit
 {
     /**
      * @var string
      */
     public const UNIT = 'service';
+
+    /**
+     * @inheritdoc
+     */
+    protected function getUnitSuffix(): string
+    {
+        return static::UNIT;
+    }
 }

--- a/src/Unit/Timer.php
+++ b/src/Unit/Timer.php
@@ -2,10 +2,23 @@
 
 namespace SystemCtl\Unit;
 
+/**
+ * Class Timer
+ *
+ * @package SystemCtl\Unit
+ */
 class Timer extends AbstractUnit
 {
     /**
      * @var string
      */
     public const UNIT = 'timer';
+
+    /**
+     * @inheritdoc
+     */
+    protected function getUnitSuffix(): string
+    {
+        return static::UNIT;
+    }
 }

--- a/src/Unit/UnitInterface.php
+++ b/src/Unit/UnitInterface.php
@@ -2,6 +2,7 @@
 
 namespace SystemCtl\Unit;
 
+use SystemCtl\Command\CommandInterface;
 use SystemCtl\Exception\CommandFailedException;
 
 /**
@@ -31,6 +32,11 @@ interface UnitInterface
      * @return null|string
      */
     public function getInstanceName(): ?string;
+
+    /**
+     * @return CommandInterface
+     */
+    public function execute(): CommandInterface;
 
     /**
      * Start command
@@ -79,4 +85,6 @@ interface UnitInterface
      * @throws CommandFailedException
      */
     public function enable(): bool;
+
+    // @todo: Add missing methods from AbstractUnit.
 }

--- a/src/Utils/OutputFetcher.php
+++ b/src/Utils/OutputFetcher.php
@@ -2,6 +2,11 @@
 
 namespace SystemCtl\Utils;
 
+/**
+ * Class OutputFetcher
+ *
+ * @package SystemCtl\Utils
+ */
 class OutputFetcher
 {
     /**
@@ -14,7 +19,7 @@ class OutputFetcher
      */
     public static function fetchUnitNames(string $suffix, string $output): array
     {
-        preg_match_all('/(?<unit>.*)\.' . $suffix . '\s/', $output, $matches);
+        preg_match_all('/^\s*(?<unit>.*)\.' . $suffix . '\s.*$/m', $output, $matches);
         return $matches['unit'] ?? [];
     }
 }

--- a/tests/Integration/SystemCtlTest.php
+++ b/tests/Integration/SystemCtlTest.php
@@ -7,14 +7,21 @@ use Prophecy\Argument;
 use Prophecy\Prophecy\ObjectProphecy;
 use SystemCtl\Command\CommandDispatcherInterface;
 use SystemCtl\Command\CommandInterface;
-use SystemCtl\Command\SymfonyCommandDispatcher;
 use SystemCtl\Exception\UnitTypeNotSupportedException;
 use SystemCtl\SystemCtl;
 use SystemCtl\Unit\Service;
 use SystemCtl\Unit\UnitInterface;
 
+/**
+ * Class SystemCtlTest
+ *
+ * @package SystemCtl\Test\Integration
+ */
 class SystemCtlTest extends TestCase
 {
+    /**
+     * @return ObjectProphecy
+     */
     public function createCommandDispatcherStub(): ObjectProphecy
     {
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);

--- a/tests/Integration/Unit/UnitTest.php
+++ b/tests/Integration/Unit/UnitTest.php
@@ -8,8 +8,14 @@ use Prophecy\Prophecy\ObjectProphecy;
 use SystemCtl\Command\CommandDispatcherInterface;
 use SystemCtl\Command\CommandInterface;
 use SystemCtl\Exception\CommandFailedException;
-use SystemCtl\SystemCtl;
+use SystemCtl\Unit\Service;
+use SystemCtl\Unit\Timer;
 
+/**
+ * Class UnitTest
+ *
+ * @package SystemCtl\Test\Integration\Unit
+ */
 class UnitTest extends TestCase
 {
     public function testServiceCommandsIfProcessIsSuccessfulShouldReturnTrue()
@@ -20,8 +26,7 @@ class UnitTest extends TestCase
         $commandDispatcher = $this->createCommandDispatcherStub();
         $commandDispatcher->dispatch(Argument::cetera())->willReturn($command);
 
-        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcher->reveal());
-        $service = $systemctl->getService('AwesomeService');
+        $service = new Service('AwesomeService', $commandDispatcher->reveal());
 
         $this->assertTrue($service->start());
         $this->assertTrue($service->stop());
@@ -45,8 +50,7 @@ class UnitTest extends TestCase
         $commandDispatcher = $this->createCommandDispatcherStub();
         $commandDispatcher->dispatch(Argument::cetera())->willThrow(CommandFailedException::class);
 
-        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcher->reveal());
-        $service = $systemctl->getService('AwesomeService');
+        $service = new Service('AwesomeService', $commandDispatcher->reveal());
 
         $this->expectException(CommandFailedException::class);
         $service->start();
@@ -60,8 +64,7 @@ class UnitTest extends TestCase
         $commandDispatcher = $this->createCommandDispatcherStub();
         $commandDispatcher->dispatch(Argument::cetera())->willReturn($command);
 
-        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcher->reveal());
-        $timer = $systemctl->getTimer('AwesomeTimer');
+        $timer = new Timer('AwesomeService', $commandDispatcher->reveal());
 
         $this->assertTrue($timer->start());
         $this->assertTrue($timer->stop());
@@ -76,8 +79,7 @@ class UnitTest extends TestCase
         $commandDispatcher = $this->createCommandDispatcherStub();
         $commandDispatcher->dispatch(Argument::cetera())->willThrow(CommandFailedException::class);
 
-        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcher->reveal());
-        $timer = $systemctl->getTimer('AwesomeTimer');
+        $timer = new Timer('AwesomeTimer', $commandDispatcher->reveal());
 
         $this->expectException(CommandFailedException::class);
         $timer->start();

--- a/tests/Unit/SystemCtlTest.php
+++ b/tests/Unit/SystemCtlTest.php
@@ -3,27 +3,188 @@
 namespace SystemCtl\Test\Unit;
 
 use PHPUnit\Framework\TestCase;
+use Prophecy\Argument;
+use Prophecy\Prophecy\ObjectProphecy;
+use SystemCtl\Command\CommandDispatcherInterface;
+use SystemCtl\Command\CommandInterface;
+use SystemCtl\Exception\UnitNotFoundException;
 use SystemCtl\SystemCtl;
 use SystemCtl\Unit\Service;
 use SystemCtl\Unit\Timer;
 
+/**
+ * Class SystemCtlTest
+ *
+ * @package SystemCtl\Test\Unit
+ */
 class SystemCtlTest extends TestCase
 {
-    public function testGetServiceWithName()
+    /**
+     * @return ObjectProphecy
+     */
+    private function buildCommandDispatcherStub(): ObjectProphecy
     {
-        $systemctl = new SystemCtl();
+        $commandDispatcherStub = $this->prophesize(CommandDispatcherInterface::class);
+        $commandDispatcherStub->setTimeout(Argument::type('int'))->willReturn($commandDispatcherStub);
+        $commandDispatcherStub->setBinary(Argument::type('string'))->willReturn($commandDispatcherStub);
 
-        $service = $systemctl->getService('testService');
+        return $commandDispatcherStub;
+    }
+
+    /**
+     * @param string $output
+     *
+     * @return ObjectProphecy
+     */
+    private function buildCommandStub(string $output): ObjectProphecy
+    {
+        $command = $this->prophesize(CommandInterface::class);
+        $command->getOutput()->willReturn($output);
+
+        return $command;
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldCallCommandDispatcherWithListUnitsAndUnitPrefixOnServiceGetting()
+    {
+        $unitName = 'testService';
+        $output = ' testService.service     Active running';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub($output));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $service = $systemctl->getService($unitName);
         $this->assertInstanceOf(Service::class, $service);
         $this->assertEquals('testService', $service->getName());
     }
 
-    public function testGetTimerWithName()
+    /**
+     * @test
+     */
+    public function itShouldReturnAServiceOnServiceGetting()
     {
-        $systemctl = new SystemCtl();
+        $unitName = 'testService';
+        $output = ' testService.service     Active running';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub($output));
 
-        $timer = $systemctl->getTimer('testTimer');
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $service = $systemctl->getService($unitName);
+        $this->assertInstanceOf(Service::class, $service);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnAServiceWithTheCorrectNameOnServiceGetting()
+    {
+        $unitName = 'testService';
+        $output = ' testService.service     Active running';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub($output));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $service = $systemctl->getService($unitName);
+        $this->assertEquals('testService', $service->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAnExceptionIfNotServicesCouldBeFound()
+    {
+        $unitName = 'testService';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub(''));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $this->expectException(UnitNotFoundException::class);
+        $systemctl->getTimer($unitName);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldCallCommandDispatcherWithListUnitsAndUnitPrefixOnTimerGetting()
+    {
+        $unitName = 'testTimer';
+        $output = ' testTimer.timer     Active running';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub($output));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $timer = $systemctl->getTimer($unitName);
         $this->assertInstanceOf(Timer::class, $timer);
-        $this->assertEquals('testTimer', $timer->getName());
+        $this->assertEquals($unitName, $timer->getName());
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldThrowAnExeceptionIfNotTimerCouldBeFound()
+    {
+        $unitName = 'testTimer';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub(''));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $this->expectException(UnitNotFoundException::class);
+        $systemctl->getTimer($unitName);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnATimerOnTimerGetting()
+    {
+        $unitName = 'testService';
+        $output = ' testService.service     Active running';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub($output));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $service = $systemctl->getService($unitName);
+        $this->assertInstanceOf(Service::class, $service);
+    }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnATimerWithTheCorrectNameOnTimerGetting()
+    {
+        $unitName = 'testService';
+        $output = ' testService.service     Active running';
+        $commandDispatcherStub = $this->buildCommandDispatcherStub();
+        $commandDispatcherStub
+            ->dispatch(...['list-units', $unitName . '*'])
+            ->willReturn($this->buildCommandStub($output));
+
+        $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
+
+        $service = $systemctl->getService($unitName);
+        $this->assertEquals('testService', $service->getName());
     }
 }

--- a/tests/Unit/Unit/UnitStub.php
+++ b/tests/Unit/Unit/UnitStub.php
@@ -13,12 +13,10 @@ use SystemCtl\Unit\AbstractUnit;
 class UnitStub extends AbstractUnit
 {
     /**
-     * @param string $command
-     *
-     * @return bool
+     * @inheritdoc
      */
-    public function execute(string $command): bool
+    protected function getUnitSuffix(): string
     {
-        throw new \RuntimeException('Not implemented');
+        return 'stub';
     }
 }

--- a/tests/Unit/Utils/OutputFetcherTest.php
+++ b/tests/Unit/Utils/OutputFetcherTest.php
@@ -5,20 +5,127 @@ namespace SystemCtl\Test\Unit\Utils;
 use PHPUnit\Framework\TestCase;
 use SystemCtl\Utils\OutputFetcher;
 
+/**
+ * Class OutputFetcherTest
+ *
+ * @package SystemCtl\Test\Unit\Utils
+ */
 class OutputFetcherTest extends TestCase
 {
-    public function testFetchUnitNames()
+    /**
+     * @param string $output
+     * @param string $suffix
+     * @param int    $expectedAmount
+     *
+     * @test
+     * @dataProvider itDeterminesTheCorrectAmountOfUnitsDataProvider
+     */
+    public function itDeterminesTheCorrectAmountOfUnits(
+        string $output,
+        string $suffix,
+        int $expectedAmount
+    ) {
+        $units = OutputFetcher::fetchUnitNames($suffix, $output);
+        $this->assertCount($expectedAmount, $units);
+    }
+
+    /**
+     * @return array
+     */
+    public function itDeterminesTheCorrectAmountOfUnitsDataProvider(): array
     {
-        $output = <<<EOT
-PLACEHOLDER STUFF
+        $output = <<<OUTPUT
   superservice.service      Active running
   awesomeservice.service    Active running
   nonservice.timer          Active running
-PLACEHOLDER STUFF
-  
-EOT;
+  superservice.mount        Active running
+  awesomeservice.mount      Active running
+  nonservice.timer          Active running
+  superservice.service      Active running
+  awesomeservice.service    Active running
+OUTPUT;
 
-        $units = OutputFetcher::fetchUnitNames('service', $output);
-        $this->assertCount(2, $units);
+        return [
+            [
+                'output' => $output,
+                'suffix' => 'service',
+                'amount' => 4,
+            ],
+            [
+                'output' => $output,
+                'suffix' => 'timer',
+                'amount' => 2,
+            ],
+            [
+                'output' => $output,
+                'suffix' => 'mount',
+                'amount' => 2,
+            ],
+            [
+                'output' => $output,
+                'suffix' => 'notThere',
+                'amount' => 0,
+            ],
+        ];
+    }
+
+    /**
+     * @param string $output
+     * @param string $suffix
+     * @param array $expectedUnitNames
+     *
+     * @test
+     * @dataProvider itOnlyExtractsTheUnitNamesDataProvider
+     */
+    public function itOnlyExtractsTheUnitNames(string $output, string $suffix, array $expectedUnitNames)
+    {
+        $units = OutputFetcher::fetchUnitNames($suffix, $output);
+        $this->assertEquals($expectedUnitNames, $units);
+    }
+
+    /**
+     * @return array
+     */
+    public function itOnlyExtractsTheUnitNamesDataProvider(): array
+    {
+        $output = <<<OUTPUT
+  foo.service      Active running
+  foo-bar.service    Active running
+  a-timer.timer          Active running
+  super.mount        Active running
+  awesome.mount      Active running
+  nonservice.timer          Active running
+  instance-service@1.service      Active running
+  instance-service@foo.service    Active running
+OUTPUT;
+
+        return [
+            [
+                'output' => $output,
+                'suffix' => 'service',
+                'units'  => [
+                    'foo',
+                    'foo-bar',
+                    'instance-service@1',
+                    'instance-service@foo',
+                ],
+            ],
+            [
+                'output' => $output,
+                'suffix' => 'timer',
+                'units'  => [
+                    'a-timer',
+                    'nonservice',
+                ],
+            ],
+            [
+                'output' => $output,
+                'suffix' => 'mount',
+                'units'  => [
+                    'super',
+                    'awesome',
+                ],
+            ],
+        ];
     }
 }


### PR DESCRIPTION
Fix OutputFetcher to properly fetch only the unit name.

Introduce new abstract method 'getUnitSuffix'

Revert AbstractUnit tests back to use UnitStub.

Fix command execution.

Fix Integration test for unit.

Change fetching of specific units from simply instacing them to properly fetching them from the systemctl output.

Fix command execution to apply to correct unit.

Add PHPDoc.