### PR TITLE
Add new information methods (`isActiveRaw`, `isEnabledRaw` and `show`)

### DIFF
--- a/README.md
+++ b/README.md
@@ -92,6 +92,7 @@ Available unit commands are:
 - restart
 - isEnabled
 - isActive
+- show
 
 ```php
 $systemCtl = new SystemCtl();

--- a/src/Unit/AbstractUnit.php
+++ b/src/Unit/AbstractUnit.php
@@ -153,9 +153,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function isEnabled(): bool
     {
-        $output = $this->execute('is-enabled')->getOutput();
-
-        return trim($output) === 'enabled';
+        return $this->isEnabledRaw() === 'enabled';
     }
     
     /**
@@ -176,9 +174,7 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function isActive(): bool
     {
-        $output = $this->execute('is-active')->getOutput();
-
-        return trim($output) === 'active';
+        return $this->isActiveRaw() === 'active';
     }
     
     /**

--- a/src/Unit/AbstractUnit.php
+++ b/src/Unit/AbstractUnit.php
@@ -31,7 +31,6 @@ abstract class AbstractUnit implements UnitInterface
         $this->commandDispatcher = $commandDispatcher;
     }
 
-
     /**
      * @param string                     $type
      * @param string                     $name
@@ -158,6 +157,19 @@ abstract class AbstractUnit implements UnitInterface
 
         return trim($output) === 'enabled';
     }
+    
+    /**
+     * Get the raw (text) output of the `is-enabled` command.
+     *
+     * @return string
+     */
+    public function isEnabledRaw(): string
+    {
+        // We have to trim() the output, as it may end in a newline character that we don't want.   
+        $output	= \trim($this->execute('is-enabled')->getOutput());
+
+        return $output;
+    }
 
     /**
      * @return bool
@@ -167,6 +179,19 @@ abstract class AbstractUnit implements UnitInterface
         $output = $this->execute('is-active')->getOutput();
 
         return trim($output) === 'active';
+    }
+    
+    /**
+     * Get the raw (text) output of the `is-active` command.
+     *
+     * @return string
+     */
+    public function isActiveRaw(): string
+    {
+        // We have to trim() the output, as it may end in a newline character that we don't want.   
+        $output	= \trim($this->execute('is-active')->getOutput());
+
+        return $output;
     }
 
     /**

--- a/src/Unit/AbstractUnit.php
+++ b/src/Unit/AbstractUnit.php
@@ -165,8 +165,8 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function isEnabledRaw(): string
     {
-        // We have to trim() the output, as it may end in a newline character that we don't want.   
-        $output	= \trim($this->execute('is-enabled')->getOutput());
+        // We have to trim() the output, as it may end in a newline character that we don't want.
+        $output = \trim($this->execute('is-enabled')->getOutput());
 
         return $output;
     }
@@ -188,8 +188,8 @@ abstract class AbstractUnit implements UnitInterface
      */
     public function isActiveRaw(): string
     {
-        // We have to trim() the output, as it may end in a newline character that we don't want.   
-        $output	= \trim($this->execute('is-active')->getOutput());
+        // We have to trim() the output, as it may end in a newline character that we don't want.
+        $output = \trim($this->execute('is-active')->getOutput());
 
         return $output;
     }
@@ -226,7 +226,7 @@ abstract class AbstractUnit implements UnitInterface
         $outputArray = [];
         \array_walk(
             $output,
-            function($line) use(&$outputArray) {
+            function ($line) use (&$outputArray) {
                 // Skip any empty lines/lines that do not contain '=', as the raw systemd output always
                 // contains =, e.g. 'Restart=no'. If we do not have this value, then we cannot split it as below.
                 if (empty($line) || false === \strpos($line, "=")) {

--- a/src/Unit/UnitInterface.php
+++ b/src/Unit/UnitInterface.php
@@ -99,9 +99,23 @@ interface UnitInterface
     public function isActive(): bool;
 
     /**
+     * Get the raw (text) output of the `is-active` command.
+     *
+     * @return string
+     */
+    public function isActiveRaw(): string;
+
+    /**
      * Check whether unit is enabled
      *
      * @return bool
      */
     public function isEnabled(): bool;
+
+    /**
+     * Get the raw (text) output of the `is-enabled` command.
+     *
+     * @return string
+     */
+    public function isEnabledRaw(): string;
 }

--- a/src/Unit/UnitInterface.php
+++ b/src/Unit/UnitInterface.php
@@ -118,4 +118,18 @@ interface UnitInterface
      * @return string
      */
     public function isEnabledRaw(): string;
+
+    /**
+     * Get an array of debugging unit information from the output of the systemctl `show` command.
+     *
+     * The output uses the service information as the returned array key, e.g.
+     * [
+     *      'Type' => 'service',
+     *      'Restart' => 'no',
+     *      ...
+     * ]
+     *
+     * @return array
+     */
+    public function show(): array;
 }


### PR DESCRIPTION
This PR adds three new methods to help get additional information about services. We are aiming to use this library to display information about several services on a web dashboard, with the potential management of these being a secondary concern.

To this end, I've added some additional info methods:

- `isActiveRaw()`: retrieve the raw string output of the `is-active` command. We need this as we use some 'oneshot' services, which can be 'inactive' (as opposed to failed) under normal circumstances. Simply checking them to see if they are 'active', as the normal `isActive()` method does, is not enough for us: we need to raw response from the `systemctl` command. 
- `isEnabledRaw()`: retrieve the raw string output of the `is-active` command. We don't strictly need the output of this but I added it for completeness.
- `show()`: retrieve the raw string output of the `show` command but parsing it to an array. We need some more detailed information like the time a 'oneshot' last ran, and potentially the `ExecStart` line to see the command actually run for debugging. This method takes the (extensive) output of the `show` command and makes it available to be easily consumed via a correctly keyed array of the output of the command.

Happy to make changes to the above to better conform with your library. I just quickly added these methods so we could access this additional systemd information.