### PR TITLE
Change assertEquals to assertSame.

### DIFF
--- a/test/Integration/Command/SymfonyCommandDispatcherTest.php
+++ b/test/Integration/Command/SymfonyCommandDispatcherTest.php
@@ -22,6 +22,6 @@ class SymfonyCommandDispatcherTest extends TestCase
         $dispatcher->setBinary('echo');
 
         $output = $dispatcher->dispatch('a')->getOutput();
-        $this->assertEquals('a', trim($output));
+        $this->assertSame('a', trim($output));
     }
 }

--- a/test/Integration/SystemCtlTest.php
+++ b/test/Integration/SystemCtlTest.php
@@ -95,7 +95,7 @@ EOT;
         $unit = SystemCtl::unitFromSuffix('service', 'SuccessService');
         $this->assertInstanceOf(UnitInterface::class, $unit);
         $this->assertInstanceOf(Service::class, $unit);
-        $this->assertEquals('SuccessService', $unit->getName());
+        $this->assertSame('SuccessService', $unit->getName());
     }
 
     public function testCreateUnitFromUnsupportedSuffixShouldRaiseException(): void

--- a/test/Unit/Command/SymfonyCommandTest.php
+++ b/test/Unit/Command/SymfonyCommandTest.php
@@ -35,7 +35,7 @@ class SymfonyCommandTest extends TestCase
         $process->getOutput()->willReturn('test');
 
         $command = new SymfonyCommand($process->reveal());
-        $this->assertEquals('test', $command->getOutput());
+        $this->assertSame('test', $command->getOutput());
     }
 
     /**

--- a/test/Unit/SystemCtlTest.php
+++ b/test/Unit/SystemCtlTest.php
@@ -63,7 +63,7 @@ class SystemCtlTest extends TestCase
 
         $service = $systemctl->getService($unitName);
         $this->assertInstanceOf(Service::class, $service);
-        $this->assertEquals('testService', $service->getName());
+        $this->assertSame('testService', $service->getName());
     }
 
     /**
@@ -99,7 +99,7 @@ class SystemCtlTest extends TestCase
         $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
 
         $service = $systemctl->getService($unitName);
-        $this->assertEquals('testService', $service->getName());
+        $this->assertSame('testService', $service->getName());
     }
 
     /**
@@ -135,7 +135,7 @@ class SystemCtlTest extends TestCase
 
         $timer = $systemctl->getTimer($unitName);
         $this->assertInstanceOf(Timer::class, $timer);
-        $this->assertEquals($unitName, $timer->getName());
+        $this->assertSame($unitName, $timer->getName());
     }
 
     /**
@@ -154,7 +154,7 @@ class SystemCtlTest extends TestCase
 
         $socket = $systemctl->getSocket($unitName);
         $this->assertInstanceOf(Socket::class, $socket);
-        $this->assertEquals($unitName, $socket->getName());
+        $this->assertSame($unitName, $socket->getName());
     }
 
     /**
@@ -173,7 +173,7 @@ class SystemCtlTest extends TestCase
 
         $scope = $systemctl->getScope($unitName);
         $this->assertInstanceOf(Scope::class, $scope);
-        $this->assertEquals($unitName, $scope->getName());
+        $this->assertSame($unitName, $scope->getName());
     }
 
     /**
@@ -260,7 +260,7 @@ class SystemCtlTest extends TestCase
         $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
 
         $service = $systemctl->getService($unitName);
-        $this->assertEquals('testService', $service->getName());
+        $this->assertSame('testService', $service->getName());
     }
 
     /**
@@ -279,7 +279,7 @@ class SystemCtlTest extends TestCase
 
         $device = $systemctl->getDevice($unitName);
         $this->assertInstanceOf(Device::class, $device);
-        $this->assertEquals($unitName, $device->getName());
+        $this->assertSame($unitName, $device->getName());
     }
 
     /**

--- a/test/Unit/Unit/AbstractUnitTest.php
+++ b/test/Unit/Unit/AbstractUnitTest.php
@@ -31,7 +31,7 @@ class AbstractUnitTest extends TestCase
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);
         $unit = new UnitStub($name, $commandDispatcher->reveal());
 
-        $this->assertEquals($name, $unit->getName());
+        $this->assertSame($name, $unit->getName());
     }
 
     /**
@@ -79,7 +79,7 @@ class AbstractUnitTest extends TestCase
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);
         $unit = new UnitStub($name, $commandDispatcher->reveal());
 
-        $this->assertEquals($isMultiInstance, $unit->isMultiInstance());
+        $this->assertSame($isMultiInstance, $unit->isMultiInstance());
     }
 
     /**
@@ -139,7 +139,7 @@ class AbstractUnitTest extends TestCase
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);
         $unit = new UnitStub($name, $commandDispatcher->reveal());
 
-        $this->assertEquals($instanceName, $unit->getInstanceName());
+        $this->assertSame($instanceName, $unit->getInstanceName());
     }
 
     /**

--- a/test/Unit/Utils/OutputFetcherTest.php
+++ b/test/Unit/Utils/OutputFetcherTest.php
@@ -102,7 +102,7 @@ OUTPUT;
     public function itOnlyExtractsTheUnitNames(string $output, string $suffix, array $expectedUnitNames): void
     {
         $units = OutputFetcher::fetchUnitNames($suffix, $output);
-        $this->assertEquals($expectedUnitNames, $units);
+        $this->assertSame($expectedUnitNames, $units);
     }
 
     /**


### PR DESCRIPTION
AssertSame reports an error if the two elements do not share type and value.
For example: this code $this->assertEquals(3, true); give uns true :-////
Please use assertSame, not assertEquals