### PR TITLE
Using assertSame to make assertion strict

### DIFF
--- a/src/Exception/UnitTypeNotSupportedException.php
+++ b/src/Exception/UnitTypeNotSupportedException.php
@@ -9,5 +9,4 @@ namespace icanhazstring\SystemCtl\Exception;
  */
 class UnitTypeNotSupportedException extends \Exception
 {
-
 }

--- a/test/Integration/Command/SymfonyCommandDispatcherTest.php
+++ b/test/Integration/Command/SymfonyCommandDispatcherTest.php
@@ -22,6 +22,6 @@ class SymfonyCommandDispatcherTest extends TestCase
         $dispatcher->setBinary('echo');
 
         $output = $dispatcher->dispatch('a')->getOutput();
-        $this->assertEquals('a', trim($output));
+        $this->assertSame('a', trim($output));
     }
 }

--- a/test/Integration/SystemCtlTest.php
+++ b/test/Integration/SystemCtlTest.php
@@ -98,7 +98,7 @@ EOT;
         $unit = SystemCtl::unitFromSuffix('service', 'SuccessService');
         self::assertInstanceOf(UnitInterface::class, $unit);
         self::assertInstanceOf(Service::class, $unit);
-        self::assertEquals('SuccessService', $unit->getName());
+        self::assertSame('SuccessService', $unit->getName());
     }
 
     public function testCreateUnitFromUnsupportedSuffixShouldRaiseException(): void

--- a/test/Unit/Command/SymfonyCommandTest.php
+++ b/test/Unit/Command/SymfonyCommandTest.php
@@ -38,7 +38,7 @@ class SymfonyCommandTest extends TestCase
         $process->getOutput()->willReturn('test');
 
         $command = new SymfonyCommand($process->reveal());
-        self::assertEquals('test', $command->getOutput());
+        self::assertSame('test', $command->getOutput());
     }
 
     /**
@@ -64,7 +64,7 @@ class SymfonyCommandTest extends TestCase
         $process->isSuccessful()->willReturn(true);
 
         $command = new SymfonyCommand($process->reveal());
-        self::assertEquals($command, $command->run());
+        self::assertSame($command, $command->run());
     }
 
     /**

--- a/test/Unit/SystemCtlTest.php
+++ b/test/Unit/SystemCtlTest.php
@@ -70,7 +70,7 @@ class SystemCtlTest extends TestCase
         $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
 
         $service = $systemctl->getService($unitName);
-        self::assertEquals('testService', $service->getName());
+        self::assertSame('testService', $service->getName());
     }
 
     /**
@@ -106,7 +106,7 @@ class SystemCtlTest extends TestCase
         $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
 
         $service = $systemctl->getService($unitName);
-        self::assertEquals('testService', $service->getName());
+        self::assertSame('testService', $service->getName());
     }
 
     /**
@@ -125,7 +125,7 @@ class SystemCtlTest extends TestCase
 
         $mount = $systemctl->getMount($unitName);
         $this->assertInstanceOf(Mount::class, $mount);
-        $this->assertEquals($unitName, $mount->getName());
+        $this->assertSame($unitName, $mount->getName());
     }
 
     /**
@@ -161,7 +161,7 @@ class SystemCtlTest extends TestCase
 
         $timer = $systemctl->getTimer($unitName);
         self::assertInstanceOf(Timer::class, $timer);
-        self::assertEquals($unitName, $timer->getName());
+        self::assertSame($unitName, $timer->getName());
     }
 
     /**
@@ -180,7 +180,7 @@ class SystemCtlTest extends TestCase
 
         $socket = $systemctl->getSocket($unitName);
         self::assertInstanceOf(Socket::class, $socket);
-        self::assertEquals($unitName, $socket->getName());
+        self::assertSame($unitName, $socket->getName());
     }
 
     /**
@@ -199,7 +199,7 @@ class SystemCtlTest extends TestCase
 
         $scope = $systemctl->getScope($unitName);
         self::assertInstanceOf(Scope::class, $scope);
-        self::assertEquals($unitName, $scope->getName());
+        self::assertSame($unitName, $scope->getName());
     }
 
     /**
@@ -218,7 +218,7 @@ class SystemCtlTest extends TestCase
 
         $slice = $systemctl->getSlice($unitName);
         $this->assertInstanceOf(Slice::class, $slice);
-        $this->assertEquals($unitName, $slice->getName());
+        $this->assertSame($unitName, $slice->getName());
     }
 
     /**
@@ -237,7 +237,7 @@ class SystemCtlTest extends TestCase
 
         $target = $systemctl->getTarget($unitName);
         $this->assertInstanceOf(Target::class, $target);
-        $this->assertEquals($unitName, $target->getName());
+        $this->assertSame($unitName, $target->getName());
     }
 
     /**
@@ -256,7 +256,7 @@ class SystemCtlTest extends TestCase
 
         $swap = $systemctl->getSwap($unitName);
         $this->assertInstanceOf(Swap::class, $swap);
-        $this->assertEquals($unitName, $swap->getName());
+        $this->assertSame($unitName, $swap->getName());
     }
 
     /**
@@ -275,7 +275,7 @@ class SystemCtlTest extends TestCase
 
         $automount = $systemctl->getAutomount($unitName);
         $this->assertInstanceOf(Automount::class, $automount);
-        $this->assertEquals($unitName, $automount->getName());
+        $this->assertSame($unitName, $automount->getName());
     }
 
     /**
@@ -413,7 +413,7 @@ class SystemCtlTest extends TestCase
         $systemctl = (new SystemCtl())->setCommandDispatcher($commandDispatcherStub->reveal());
 
         $service = $systemctl->getService($unitName);
-        self::assertEquals('testService', $service->getName());
+        self::assertSame('testService', $service->getName());
     }
 
     /**
@@ -432,7 +432,7 @@ class SystemCtlTest extends TestCase
 
         $device = $systemctl->getDevice($unitName);
         self::assertInstanceOf(Device::class, $device);
-        self::assertEquals($unitName, $device->getName());
+        self::assertSame($unitName, $device->getName());
     }
 
     /**

--- a/test/Unit/Unit/AbstractUnitTest.php
+++ b/test/Unit/Unit/AbstractUnitTest.php
@@ -34,7 +34,7 @@ class AbstractUnitTest extends TestCase
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);
         $unit = new UnitStub($name, $commandDispatcher->reveal());
 
-        self::assertEquals($name, $unit->getName());
+        self::assertSame($name, $unit->getName());
     }
 
     /**
@@ -97,7 +97,7 @@ class AbstractUnitTest extends TestCase
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);
         $unit = new UnitStub($name, $commandDispatcher->reveal());
 
-        self::assertEquals($isMultiInstance, $unit->isMultiInstance());
+        self::assertSame($isMultiInstance, $unit->isMultiInstance());
     }
 
     /**
@@ -177,7 +177,7 @@ class AbstractUnitTest extends TestCase
         $commandDispatcher = $this->prophesize(CommandDispatcherInterface::class);
         $unit = new UnitStub($name, $commandDispatcher->reveal());
 
-        self::assertEquals($instanceName, $unit->getInstanceName());
+        self::assertSame($instanceName, $unit->getInstanceName());
     }
 
     /**

--- a/test/Unit/Utils/OutputFetcherTest.php
+++ b/test/Unit/Utils/OutputFetcherTest.php
@@ -135,7 +135,7 @@ OUTPUT;
     public function itOnlyExtractsTheUnitNames(string $output, string $suffix, array $expectedUnitNames): void
     {
         $units = OutputFetcher::fetchUnitNames($suffix, $output);
-        self::assertEquals($expectedUnitNames, $units);
+        self::assertSame($expectedUnitNames, $units);
     }
 
     /**


### PR DESCRIPTION
# Change log

- Using the `assertSame` to make assertion equals strict.
- Fixing the following coding style via `PHP_CodeSniffer`:

```
FILE: ...hp/systemctl-php/src/Exception/UnitTypeNotSupportedException.php
----------------------------------------------------------------------
FOUND 1 ERROR AFFECTING 1 LINE
----------------------------------------------------------------------
 11 | ERROR | [x] Opening brace must not be followed by a blank
    |       |     line (PSR12.Classes.OpeningBraceSpace.Found)
----------------------------------------------------------------------
PHPCBF CAN FIX THE 1 MARKED SNIFF VIOLATIONS AUTOMATICALLY
----------------------------------------------------------------------
```