### PR TITLE
Use binary-only images for installing Composer

### DIFF
--- a/.docker/php7.4/Dockerfile
+++ b/.docker/php7.4/Dockerfile
@@ -2,7 +2,7 @@ FROM php:7.4-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 WORKDIR /docker

--- a/.docker/php8.0/Dockerfile
+++ b/.docker/php8.0/Dockerfile
@@ -1,8 +1,8 @@
-FROM php:8.0.0RC2-alpine
+FROM php:8.0-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 
-COPY --from=composer:latest /usr/bin/composer /usr/bin/composer
+COPY --from=composer/composer:latest-bin /composer /usr/bin/composer
 ENV COMPOSER_ALLOW_SUPERUSER 1
 
 WORKDIR /docker

--- a/.docker/php8.1/Dockerfile
+++ b/.docker/php8.1/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-alpine
+FROM php:8.1-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 

--- a/.docker/php8.2/Dockerfile
+++ b/.docker/php8.2/Dockerfile
@@ -1,4 +1,4 @@
-FROM php:7.3-alpine
+FROM php:8.2.0RC5-alpine
 
 COPY --from=mlocati/php-extension-installer /usr/bin/install-php-extensions /usr/bin/
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -21,3 +21,17 @@ services:
     volumes:
       - .:/docker:rw
     tty: true
+
+  php8.1:
+    build: .docker/php8.1
+    container_name: systemctl-php-8.1
+    volumes:
+      - .:/docker:rw
+    tty: true
+
+  php8.2:
+    build: .docker/php8.2
+    container_name: systemctl-php-8.2
+    volumes:
+      - .:/docker:rw
+    tty: true


### PR DESCRIPTION
See: https://blog.codito.dev/2022/11/composer-binary-only-docker-images/

Additionally I added support for missing PHP versions through Docker Compose 🙂