### PR TITLE
Improve Composer option strategy

### DIFF
--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -69,11 +69,6 @@ jobs:
         php-version: ["7.3", "7.4", "8.0", "8.1"]
         operating-system: ["ubuntu-latest"]
         experimental: [false]
-        include:
-          - php: "8.0"
-            composer-options: "--ignore-platform-req=php"
-          - php: "8.1"
-            composer-options: "--ignore-platform-req=php"
 
     steps:
       - name: Checkout
@@ -85,8 +80,13 @@ jobs:
           php-version: ${{ matrix.php-version }}
           tools: "composer:v2"
 
-      - name: Install dependencies
-        run: composer install --no-progress --prefer-dist --optimize-autoloader ${{ matrix.composer-options }}
+      - name: Install dependencies for PHP 7
+        if: matrix.php-version < '8.0'
+        run: composer install --no-progress --prefer-dist --optimize-autoloader
+
+      - name: Install dependencies for PHP 8
+        if: matrix.php-version >= '8.0'
+        run: composer install --no-progress --prefer-dist --optimize-autoloader --ignore-platform-req=php
 
       - name: Execute tests
         run: vendor/bin/phpunit --colors=always --coverage-text


### PR DESCRIPTION
# Changed log

- Improving the Composer option strategy for adding the `--ignore-platform-req=php` when running tests with `PHP 8.x`.
- Improving the Composer option strategy for without using the `--ignore-platform-req=php` when running tests with `PHP 7.x`.